### PR TITLE
Set room notification JSON POST body to UTF-8

### DIFF
--- a/src/com/whatsthatlight/teamcity/hipchat/HipChatApiProcessor.java
+++ b/src/com/whatsthatlight/teamcity/hipchat/HipChatApiProcessor.java
@@ -20,6 +20,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.Charset;
 import java.util.ArrayList;
 
 import org.apache.http.HttpHeaders;
@@ -116,7 +117,7 @@ public class HipChatApiProcessor {
 			HttpPost postRequest = new HttpPost(uri.toString());
 			postRequest.addHeader(HttpHeaders.AUTHORIZATION, authorisationHeader);
 			postRequest.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON.toString());
-			postRequest.setEntity(new StringEntity(json));
+			postRequest.setEntity(new StringEntity(json, Charset.forName("UTF-8")));
 			HttpResponse postResponse = client.execute(postRequest);
 			StatusLine status = postResponse.getStatusLine();
 			if (status.getStatusCode() != HttpStatus.SC_NO_CONTENT) {


### PR DESCRIPTION
Without this change, room notification POSTs being sent to HipChat's REST API containing non-ASCII characters will fail to work, as a decoding issue prevents the notifications from being accepted.  The JSON specification indicates that the application/json media-type should always be encoded in Unicode, but the single-arg StringEntity() constructor assumes the text/plain media type, which defaults to encoding as ISO-8859-1, as indicated in the HTTP specification.
