### PR TITLE
Add link to token generation page to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ I will gladly provide information and experiences by others here.
 
 # Configuration
 
-On HipChat, create a user account to represent the build server and generate a token for that user. 
+On HipChat, create a user account to represent the build server and generate a V2 API token for that user (https://youraccountname.hipchat.com/account/api). 
 Note: There are two HipChat APIs, so ensure your token is for the v2 API and not the v1 API. 
 
 On TeamCity, as an administrator, configure the generated token and other settings on the Administration panel.


### PR DESCRIPTION
I tried to add the TeamCity integration from https://accountname.hipchat.com/admin/addons instead of the personal API. Added an example link to perhaps help someone else in the future.